### PR TITLE
Implement chunking to circumvent M-Pathways API limit (#15)

### DIFF
--- a/pe/orchestration.py
+++ b/pe/orchestration.py
@@ -15,6 +15,7 @@ from constants import (
     CANVAS_SCOPE, CANVAS_URL_BEGIN, ISO8601_FORMAT, MPATHWAYS_SCOPE, MPATHWAYS_URL
 )
 from pe.models import Exam, Submission
+from util import chunk_list
 
 
 LOGGER = logging.getLogger(__name__)
@@ -232,8 +233,10 @@ class ScoresOrchestration:
 
         # Send scores and update the database
         if len(regular_subs) > 0:
-            # Send all regular submissions at once
-            self.send_scores(regular_subs)
+            # Send regular submissions in chunks of 100
+            regular_sub_lists: List[List[Submission]] = chunk_list(regular_subs)
+            for regular_sub_list in regular_sub_lists:
+                self.send_scores(regular_sub_list)
         if len(dup_uniqname_subs) > 0:
             LOGGER.info('Found submissions to send with duplicate uniqnames; they will be sent individually')
             # Send each submission with a duplicate uniqname individually

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -28,8 +28,8 @@ class ChunkingTestCase(TestCase):
         self.assertEqual(len(result[1]), 100)
         self.assertEqual(len(result[2]), 50)
 
-        all: List[int] = [random_num for sublist in result for random_num in sublist]
-        self.assertEqual(all, random_nums)
+        all_nums: List[int] = [random_num for sublist in result for random_num in sublist]
+        self.assertEqual(random_nums, all_nums)
 
     def test_chunk_list_of_random_nums_with_default_size_and_less_than_one_chunk(self):
         """
@@ -48,10 +48,10 @@ class ChunkingTestCase(TestCase):
         """
         submissions: List[Submission] = list(Exam.objects.get(id=1).submissions.all())
         result: List[List[Submission]] = chunk_list(submissions, chunk_size=2)
-        
+
         self.assertEqual(len(result), 2)
         self.assertEqual(len(result[0]), 2)
         self.assertEqual(len(result[1]), 1)
 
-        all: List[Submission] = [submission for sublist in result for submission in sublist]
-        self.assertEqual(self.submissions, all)
+        all_subs: List[Submission] = [submission for sublist in result for submission in sublist]
+        self.assertEqual(submissions, all_subs)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -53,5 +53,5 @@ class ChunkingTestCase(TestCase):
         self.assertEqual(len(result[0]), 2)
         self.assertEqual(len(result[1]), 1)
 
-        all: List[int] = [submission for sublist in result for submission in sublist]
+        all: List[Submission] = [submission for sublist in result for submission in sublist]
         self.assertEqual(self.submissions, all)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,0 +1,57 @@
+# standard libraries
+import logging, random
+from typing import List
+
+# third-party libraries
+from django.test import TestCase
+
+# local libraries
+from pe.models import Exam, Submission
+from util import chunk_list
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ChunkingTestCase(TestCase):
+    fixtures: List[str] = ['test_01.json', 'test_04.json']
+
+    def test_chunk_list_of_random_nums_with_default_size_and_multiple_chunks(self):
+        """
+        chunk_list creates a list of three integer lists of lengths 100, 100, and 50 with default chunk_size.
+        """
+        random_nums: List[int] = random.sample(range(1000000), 250)
+        result: List[List[int]] = chunk_list(random_nums)
+
+        self.assertEqual(len(result), 3)
+        self.assertEqual(len(result[0]), 100)
+        self.assertEqual(len(result[1]), 100)
+        self.assertEqual(len(result[2]), 50)
+
+        all: List[int] = [random_num for sublist in result for random_num in sublist]
+        self.assertEqual(all, random_nums)
+
+    def test_chunk_list_of_random_nums_with_default_size_and_less_than_one_chunk(self):
+        """
+        chunk_list creates a list containing one element, also a list, when input length is less than chunk_size.
+        """
+        random_nums: List[int] = random.sample(range(1000000), 70)
+        result: List[List[int]] = chunk_list(random_nums)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result[0]), 70)
+        self.assertEqual(result[0], random_nums)
+
+    def test_chunk_list_of_subs_with_custom_size_and_more_than_one_chunk(self):
+        """
+        chunk_list chunks a list of three submissions into a list of two lists with length 2 and 1 when chunk_size is 2.
+        """
+        submissions: List[Submission] = list(Exam.objects.get(id=1).submissions.all())
+        result: List[List[Submission]] = chunk_list(submissions, chunk_size=2)
+        
+        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result[0]), 2)
+        self.assertEqual(len(result[1]), 1)
+
+        all: List[int] = [submission for sublist in result for submission in sublist]
+        self.assertEqual(self.submissions, all)

--- a/util.py
+++ b/util.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Any, List
 
+
 LOGGER = logging.getLogger(__name__)
 
 

--- a/util.py
+++ b/util.py
@@ -1,0 +1,12 @@
+# standard libraries
+import logging
+from typing import Any, List
+
+LOGGER = logging.getLogger(__name__)
+
+
+def chunk_list(input_list: List[Any], chunk_size: int = 100):
+    """Chunks a given list into a list of lists of a specified size."""
+    chunks = [input_list[x:x + chunk_size] for x in range(0, len(input_list), chunk_size)]
+    LOGGER.debug(chunks)
+    return chunks

--- a/util.py
+++ b/util.py
@@ -6,8 +6,8 @@ from typing import Any, List
 LOGGER = logging.getLogger(__name__)
 
 
-def chunk_list(input_list: List[Any], chunk_size: int = 100):
+def chunk_list(input_list: List[Any], chunk_size: int = 100) -> List[List[Any]]:
     """Chunks a given list into a list of lists of a specified size."""
-    chunks = [input_list[x:x + chunk_size] for x in range(0, len(input_list), chunk_size)]
+    chunks: List[List[Any]] = [input_list[x:x + chunk_size] for x in range(0, len(input_list), chunk_size)]
     LOGGER.debug(chunks)
     return chunks


### PR DESCRIPTION
This PR introduces a `util.py` module containing only the function `chunk_list`, which is then used to break up a larger list of submissions into smaller lists so as to avoid an ambiguous size limit in requests sent to the M-Pathways endpoint. Unit tests are included. The PR aims to resolve issue #15.