### PR TITLE
Discard Canvas submissions with no score

### DIFF
--- a/pe/orchestration.py
+++ b/pe/orchestration.py
@@ -106,7 +106,7 @@ class ScoresOrchestration:
         if filter_diff > 0:
             LOGGER.info(f'Discarded {filter_diff} Canvas submission(s) with no score(s)')
 
-        LOGGER.info(f'Gathered {len(sub_dicts_with_scores)} submissions from Canvas')
+        LOGGER.info(f'Gathered {len(sub_dicts_with_scores)} submission(s) from Canvas')
         LOGGER.debug(sub_dicts_with_scores)
         return sub_dicts_with_scores
 

--- a/pe/orchestration.py
+++ b/pe/orchestration.py
@@ -101,9 +101,14 @@ class ScoresOrchestration:
                     next_params = page_info
                     page_num += 1
 
-        LOGGER.info(f'Gathered {len(sub_dicts)} submissions from Canvas')
-        LOGGER.debug(sub_dicts)
-        return sub_dicts
+        sub_dicts_with_scores: List[Dict[str, Any]] = list(filter((lambda x: x['score'] is not None), sub_dicts))
+        filter_diff: int = len(sub_dicts) - len(sub_dicts_with_scores)
+        if filter_diff > 0:
+            LOGGER.info(f'Discarded {filter_diff} Canvas submission(s) with no score(s)')
+
+        LOGGER.info(f'Gathered {len(sub_dicts_with_scores)} submissions from Canvas')
+        LOGGER.debug(sub_dicts_with_scores)
+        return sub_dicts_with_scores
 
     def create_sub_records(self, sub_dicts: List[Dict[str, Any]]) -> None:
         """

--- a/test/api_fixtures/canvas_subs.json
+++ b/test/api_fixtures/canvas_subs.json
@@ -61,5 +61,29 @@
                 "login_id": "nlongbottom"
             }
         }
+    ],
+    "DADA_Placement_2": [
+        {
+            "id": 888889,
+            "attempt": 1,
+            "score": 600.0,
+            "submitted_at": "2020-07-08T22:03:00Z",
+            "assignment_id": 222222,
+            "graded_at": "2020-07-09T10:15:00Z",
+            "user": {
+                "login_id": "hpotter"
+            }
+        },
+        {
+            "id": 888890,
+            "attempt": 1,
+            "score": null,
+            "submitted_at": "2020-07-08T23:30:45Z",
+            "assignment_id": 222222,
+            "graded_at": "2020-07-09T10:16:00Z",
+            "user": {
+                "login_id": "rweasley"
+            }
+        }
     ]
 }


### PR DESCRIPTION
This PR modifies the `get_sub_dicts_for_exam` method of `ScoresOrchestration` to filter out `sub_dicts` (Canvas submissions) that have `null` values in the `score` field. This situation can occur if an instructor enters a grade for a submission and then removes that score. New fixtures and a test are provided. The PR aims to resolve issue #26.