### PR TITLE
Update api-utils-python egg, bump some pypi dependencies (#25, #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ To run the test suite, use the following commands:
 
 ```sh
 coverage run manage.py test -v 3
+coverage report
 ```
 
 #### Sending email

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ You can also set up the application using `virtualenv` by doing the following:
 To run the test suite, use the following commands:
 
 ```sh
-coverage manage.py test -v 3
+coverage run manage.py test -v 3
 ```
 
 #### Sending email

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-coverage==5.1
-Django==3.0.7
+coverage==5.2.1
+Django==3.0.9
 mysqlclient==1.4.6
-python-dotenv==0.13.0
--e git+https://github.com/tl-its-umich-edu/api-utils-python@master#egg=umich-api
+python-dotenv==0.14.0
+-e git+https://github.com/tl-its-umich-edu/api-utils-python@v2.0#egg=umich-api


### PR DESCRIPTION
This PR modifies `requirements.txt` so that the `api-utils-python` egg references a release (`v2.0`) instead of `master` and that we're using the latest low-risk release for the other `pypi` dependencies. Notably, I elected to postpone using more significant release of `Django` (`3.1`) and `mysqlclient` (`2.0.1`); see issue #33 for more details on my thinking on each of the `pypi` package changes. I also am fixing a sample command in the `README.md` for running the test suite with `coverage` and `virtualenv`. The PR aims to resolve issues #25 and #33.