### PR TITLE
Modify database, settings.py to use utf8mb4 (#37)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   mysql:
     image: mysql:5.7
     restart: on-failure
+    command: ['--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
     environment:
       - MYSQL_ROOT_PASSWORD=pe_root_pw
       - MYSQL_HOST=placement_exams_mysql

--- a/pe/settings.py
+++ b/pe/settings.py
@@ -12,14 +12,19 @@ BASE_DIR: str = ROOT_DIR
 
 CONFIG_DIR: str = os.path.join(BASE_DIR, os.getenv('ENV_DIR', os.path.join('config', 'secrets')))
 
-DATABASES: Dict[str, Dict[str, str]] = {
+DATABASES: Dict[str, Dict[str, Any]] = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': os.getenv('DB_NAME', 'placement_exams_local'),
         'USER': os.getenv('DB_USER', 'pe_user'),
         'PASSWORD': os.getenv('DB_PASSWORD', 'pe_pw'),
         'HOST': os.getenv('DB_HOST', 'placement_exams_mysql'),
-        'PORT': os.getenv('DB_PORT', '3306')
+        'PORT': os.getenv('DB_PORT', '3306'),
+        'OPTIONS': {'charset': 'utf8mb4'},
+        'TEST': {
+            'CHARSET': 'utf8mb4',
+            'COLLATION': 'utf8mb4_unicode_ci'
+        }
     }
 }
 

--- a/test/fixtures/test_05.json
+++ b/test/fixtures/test_05.json
@@ -1,0 +1,22 @@
+[
+    {
+        "model": "pe.report",
+        "pk": 4,
+        "fields": {
+            "name": "Divination 🔮",
+            "contact": "trelawn@hogwarts.edu"
+        }
+    },
+    {
+        "model": "pe.exam",
+        "pk": 4,
+        "fields": {
+            "sa_code": "Δ",
+            "name": "Δ𓀤𝌕👁",
+            "report_id": 4,
+            "course_id": 1111111,
+            "assignment_id": 777777,
+            "default_time_filter": "2020-08-01T00:00:00Z"
+        }
+    }
+]

--- a/test/test_pe.py
+++ b/test/test_pe.py
@@ -218,6 +218,15 @@ class LoadFixturesTestCase(TestCase):
         self.assertEqual(submission.exam.sa_code, 'PP')
         self.assertEqual(submission.exam.name, 'Potions Placement Advanced')
 
+    def test_load_fixtures_with_supplementary_characters(self):
+        """Loading exam and report fixtures with characters that need utf8mb4 encoding succeeds."""
+        call_command('loaddata', 'test_05.json')
+        div_report: Report = Report.objects.get(id=4)
+        self.assertEqual(div_report.name, 'Divination 🔮')
+        div_exam: Exam = div_report.exams.first()
+        self.assertEqual(div_exam.sa_code, 'Δ')
+        self.assertEqual(div_exam.name, 'Δ𓀤𝌕👁')
+
 
 class StringMethodsTestCase(TestCase):
     fixtures: List[str] = ['test_01.json', 'test_04.json']


### PR DESCRIPTION
To keep in sync with other T&L applications, this PR modifies `docker-compose.yml` and `settings.py` so that we use the `utf8mb4` encoding and associated collation to help handle supplementary characters that can't be dealt with using `mysql`'s standard `utf8` encoding. Because this is a new application with no need to preserve existing data or tables, no migration converting tables and fields is necessary. More details about the changes are provided in the task list below. The PR aims to resolve issue #37.

- [x] Modify `docker-compose.yml` so that the Docker `mysql` server uses the `utf8mb4` character set and `utf8mb4_unicode_ci` collation at the server level, thereby setting the default for all databases. This mimics actions that have been taken by our DBA team.
- [x] Modify `settings.py` to include the `OPTIONS` and `TEST` settings laid out in the [`django_mysql` docs](https://django-mysql.readthedocs.io/en/latest/checks.html#django-mysql-w003-utf8mb4). The `OPTIONS` change instructors the database connection driver to use `utf8mb4`, while the `TEST` change instructs Django to create the database with the desired character set and collation (this second change may not be strictly necessary, because of the `docker-compose` changes, but it seems like a little clearer to be explicit).
- [x] Add fixtures with supplementary characters in some `Report` and `Exam` `VARCHAR` fields and unit tests to `test_pe.py` that load them to the database. Note that I am not testing these characters in `Submission.student_uniqname`, as they are not currently supported by the M-Pathways endpoint (see #13). However, the database should have no problem storing them.