### PR TITLE
Strip whitespace characters from Canvas login_id values (#36)

### DIFF
--- a/pe/orchestration.py
+++ b/pe/orchestration.py
@@ -127,7 +127,7 @@ class ScoresOrchestration:
                             submission_id=sub_dict['id'],
                             attempt_num=sub_dict['attempt'],
                             exam=self.exam,
-                            student_uniqname=sub_dict['user']['login_id'],
+                            student_uniqname=sub_dict['user']['login_id'].strip(),
                             submitted_timestamp=sub_dict['submitted_at'],
                             graded_timestamp=sub_dict['graded_at'],
                             score=sub_dict['score'],

--- a/test/api_fixtures/canvas_subs.json
+++ b/test/api_fixtures/canvas_subs.json
@@ -25,6 +25,30 @@
             }
         }
     ],
+    "Potions_Placement_3": [
+        {
+            "id": 123461,
+            "attempt": 1,
+            "score": 450.0,
+            "submitted_at": "2020-06-15T21:00:00Z",
+            "assignment_id": 111112,
+            "graded_at": "2020-06-15T21:30:00Z",
+            "user": {
+                "login_id": " visitor_one@magicking.edu "
+            }
+        },
+        {
+            "id": 123462,
+            "attempt": 1,
+            "score": 375.0,
+            "submitted_at": "2020-06-16T01:15:00Z",
+            "assignment_id": 111112,
+            "graded_at": "2020-06-16T12:01:00Z",
+            "user": {
+                "login_id": "\tvisitor_two@magicking.edu\n"
+            }
+        }
+    ],
     "Potions_Validation_1": [
         {
             "id": 444444,

--- a/test/test_orch.py
+++ b/test/test_orch.py
@@ -45,6 +45,7 @@ class ScoresOrchestrationTestCase(TestCase):
         self.canvas_potions_val_subs: List[Dict[str, Any]] = canvas_subs_dict['Potions_Validation_1']
         self.canvas_dada_place_subs_one: List[Dict[str, Any]] = canvas_subs_dict['DADA_Placement_1']
         self.canvas_dada_place_subs_two: List[Dict[str, Any]] = canvas_subs_dict['DADA_Placement_2']
+        self.canvas_potions_place_subs_three: List[Dict[str, Any]] = canvas_subs_dict['Potions_Placement_3']
 
         with open(os.path.join(API_FIXTURES_DIR, 'mpathways_resp_data.json'), 'r') as mpathways_resp_data_file:
             self.mpathways_resp_data: List[Dict[str, Any]] = json.loads(mpathways_resp_data_file.read())
@@ -216,6 +217,16 @@ class ScoresOrchestrationTestCase(TestCase):
                 'graded_timestamp': datetime(2020, 7, 7, 13, 22, 49, tzinfo=utc)
             }
         )
+
+    def test_create_sub_records_strips_whitespace_in_login_id(self):
+        """create_sub_records strips leading and trailing whitespace characters from Canvas login_ids."""
+        potions_place_exam: Exam = Exam.objects.get(id=1)
+        some_orca: ScoresOrchestration = ScoresOrchestration(self.api_handler, potions_place_exam)
+        some_orca.create_sub_records(self.canvas_potions_place_subs_three)
+
+        latest_two_subs: List[Submission] = list(Submission.objects.filter(exam=potions_place_exam).order_by('-id'))[:2]
+        uniqnames: List[str] = [sub.student_uniqname for sub in latest_two_subs]
+        self.assertEqual(uniqnames, ['visitor_two@magicking.edu', 'visitor_one@magicking.edu'])
 
     def test_send_scores_when_successful(self):
         """


### PR DESCRIPTION
This PR makes a minor modification to `ScoresOrchestration.create_sub_records` to strip leading and trailing whitespace from Canvas user `login_id`s, which are cross-walked to `Submission.student_uniqname`. This change is being proposed to avoid a bug downstream in the process: the M-Pathways endpoint strips whitespace, as well, meaning that if our application does not, we may send one value across and get a different one back, leading to the transmission being interpreted as a failure. The possibility of leading and trailing whitespace should only occur with friend accounts. The PR includes fixtures with leading and trailing whitespace -- specifically ` `, ` ` or a [non-breaking space](https://en.wikipedia.org/wiki/Non-breaking_space), `\t`, and `\n` -- and a unit test ensuring those characters are stripped. The PR aims to resolve issue #36.