### PR TITLE
Maybe send email (#41)

### DIFF
--- a/pe/main.py
+++ b/pe/main.py
@@ -50,9 +50,13 @@ def main(api_util: ApiUtil) -> None:
                 'sub_time_filter': exam_orca.sub_time_filter
             }
             reporter.exams_time_metadata[exam.id] = metadata
+
         reporter.prepare_context()
-        LOGGER.info(f'Sending {report.name} report email to {report.contact}')
-        reporter.send_email()
+        if reporter.total_successes > 0 or reporter.total_failures > 0:
+            LOGGER.info(f'Sending {report.name} report email to {report.contact}')
+            reporter.send_email()
+        else:
+            LOGGER.info(f'No email will be sent for the {report.name} report as there was no transmission activty.')
 
     end_time: datetime = datetime.now(tz=utc)
     delta: timedelta = end_time - start_time

--- a/pe/main.py
+++ b/pe/main.py
@@ -56,7 +56,7 @@ def main(api_util: ApiUtil) -> None:
             LOGGER.info(f'Sending {report.name} report email to {report.contact}')
             reporter.send_email()
         else:
-            LOGGER.info(f'No email will be sent for the {report.name} report as there was no transmission activty.')
+            LOGGER.info(f'No email will be sent for the {report.name} report as there was no transmission activity.')
 
     end_time: datetime = datetime.now(tz=utc)
     delta: timedelta = end_time - start_time

--- a/pe/reporter.py
+++ b/pe/reporter.py
@@ -39,7 +39,8 @@ class Reporter:
 
     def prepare_context(self) -> None:
         """
-        Prepares the context in a dictionary structure that can be passed to the template via render_to_string.
+        Prepares summary counts and the context in a dictionary structure that can be passed to the template
+        via render_to_string.
 
         :return: None
         :rtype: None

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -38,7 +38,7 @@ class MainTestCase(TestCase):
         with open(os.path.join(API_FIXTURES_DIR, 'mpathways_resp_data.json'), 'r') as mpathways_resp_data_file:
             self.mpathways_resp_data: List[Dict[str, Any]] = json.loads(mpathways_resp_data_file.read())
 
-    def test_main(self):
+    def test_main_sends_email_when_transmissions_succeed(self):
         """
         Function main successfully uses ScoresOrchestration and Reporter classes to collect, transmit, and
         report by email on new exam submissions.

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -41,7 +41,7 @@ class MainTestCase(TestCase):
     def test_main(self):
         """
         Function main successfully uses ScoresOrchestration and Reporter classes to collect, transmit, and
-        report on new exam submissions.
+        report by email on new exam submissions.
         """
         with patch('pe.orchestration.api_call_with_retries', autospec=True) as mock_get:
             with patch.object(ApiUtil, 'api_call', autospec=True) as mock_send:
@@ -59,4 +59,35 @@ class MainTestCase(TestCase):
             list(new_submissions_qs.values('student_uniqname', 'score', 'transmitted')),
             [{'student_uniqname': 'nlongbottom', 'score': 500.0, 'transmitted': True}]
         )
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_main_does_not_send_email_when_no_transmission_activity(self):
+        """
+        Function main does not send email when there are no successful or failed transmissions.
+        (Note this also implies that there were no new submissions found.)
+        """
+        with patch('pe.orchestration.api_call_with_retries', autospec=True) as mock_get:
+            mock_get.return_value = MagicMock(spec=Response, status_code=200, text=json.dumps([]))
+            main(self.api_handler)
+
+        dada_report: Report = Report.objects.get(id=3)
+        new_submissions_qs: QuerySet = dada_report.exams.first().submissions.all()
+        self.assertFalse(new_submissions_qs.exists())
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_main_sends_email_when_only_transmission_failures(self):
+        """
+        Function main still sends email when there are failed transmissions.
+        """
+        with patch('pe.orchestration.api_call_with_retries', autospec=True) as mock_get:
+            with patch.object(ApiUtil, 'api_call', autospec=True) as mock_send:
+                mock_get.return_value = MagicMock(
+                    spec=Response, status_code=200, text=json.dumps(self.canvas_dada_place_subs)
+                )
+                mock_send.return_value = MagicMock(spec=Response, status_code=500, text=json.dumps({}))
+                main(self.api_handler)
+
+        dada_report: Report = Report.objects.get(id=3)
+        failed_submissions_qs: QuerySet = dada_report.exams.first().submissions.filter(transmitted=False)
+        self.assertTrue(len(failed_submissions_qs), 2)
         self.assertEqual(len(mail.outbox), 1)


### PR DESCRIPTION
This PR adds logic so that emails are only sent when the application tries (with a resulting success or failure) to send scores to M-Pathways. Note that the application will always tried to send scores when new submissions are found in Canvas, meaning that they will be reflected in the success and failure counts. This PR builds on the work started in PR #42. The PR aims to resolve issue #41.