### PR TITLE
Change Canvas request parameter strings to use standard approach (#47)

### DIFF
--- a/pe/orchestration.py
+++ b/pe/orchestration.py
@@ -66,10 +66,10 @@ class ScoresOrchestration:
         get_subs_url: str = f'{CANVAS_URL_BEGIN}/courses/{self.exam.course_id}/students/submissions'
 
         canvas_params: Dict[str, Any] = {
-            'student_ids': ['all'],
-            'assignment_ids': [str(self.exam.assignment_id)],
+            'student_ids[]': 'all',
+            'assignment_ids[]': str(self.exam.assignment_id),
             'per_page': page_size,
-            'include': ['user'],
+            'include[]': 'user',
             'graded_since': self.sub_time_filter.strftime(ISO8601_FORMAT)
         }
 


### PR DESCRIPTION
This PR changes the Canvas parameter strings used in `ScoresOrchestration.get_sub_dicts_for_exam()` to use the standard strings laid out in the documentation and suggested by the community (see the linked issue for more details). I verified that the application collects the same data given the same course and time filter details with both either string approach, but staying closer to the Canvas documentation seems like a good idea. The PR aims to resolve issue #47.