### PR TITLE
Make maximum request attempts configurable (#32)

### DIFF
--- a/api_retry/util.py
+++ b/api_retry/util.py
@@ -58,10 +58,10 @@ def api_call_with_retries(
     :type subscription: string
     :param method: Request method that should be used (e.g. "GET", "PUT")
     :type method: string
-    :param payload: Optional dictionary for sending in the request body
+    :param payload: Dictionary to include in the request body
     :type payload: Dictionary with string keys or None, optional
     :param max_req_attempts: Number of request attempts to make before logging an error
-    :type max_req_attempts: int
+    :type max_req_attempts: int, optional
     :return: Either a Response object or None
     :rtype: Response or None
     """

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -6,6 +6,9 @@ API_DIR_URL=
 API_DIR_CLIENT_ID=
 API_DIR_SECRET=
 
+# Number of attempts to make for a unique Canvas data request before stopping
+MAX_REQ_ATTEMPTS=3
+
 # Application Database
 # Provided values are for database managed by docker-compose
 DB_NAME=placement_exams_local

--- a/pe/orchestration.py
+++ b/pe/orchestration.py
@@ -1,5 +1,5 @@
 # standard libraries
-import json, logging
+import json, logging, os
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Union
 
@@ -19,6 +19,8 @@ from util import chunk_list
 
 
 LOGGER = logging.getLogger(__name__)
+
+MAX_REQ_ATTEMPTS = int(os.getenv('MAX_REQ_ATTEMPTS', '3'))
 
 
 class ScoresOrchestration:
@@ -86,7 +88,8 @@ class ScoresOrchestration:
                 get_subs_url,
                 CANVAS_SCOPE,
                 'GET',
-                next_params
+                next_params,
+                MAX_REQ_ATTEMPTS
             )
             if response is None:
                 LOGGER.info('api_call_with_retries failed to get a response; no more data will be collected')


### PR DESCRIPTION
The PR updates `orchestration.py` and `.env.sample` to make the maximum number of attempts (used with `api_call_with_retries`) while fetching Canvas data adjustable via the `.env` configuration file. The PR aims to resolve issue #32.