### PR TITLE
Update dependencies where possible (#52)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-coverage==5.2.1
-Django==3.0.9
-mysqlclient==1.4.6
+coverage==5.5
+Django==3.1.7
+mysqlclient==2.0.3
 python-dotenv==0.14.0
 -e git+https://github.com/tl-its-umich-edu/api-utils-python@v2.0#egg=umich-api


### PR DESCRIPTION
This PR updates the `coverage`, `Django`, and `mysqlclient` dependencies to the latest available versions. `python-dotenv` was held back due to incompatibility with `api-utils-python` (which only allows `0.14.X`). The test suite passed, and the application ran properly in the test environment. The PR aims to resolve #52.