### PR TITLE
Update to latest version of Django 3.2 (#65)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coverage==5.5
-Django==3.1.8
+Django==3.2.5
 mysqlclient==2.0.3
 python-dotenv==0.14.0
 -e git+https://github.com/tl-its-umich-edu/api-utils-python@v2.0#egg=umich-api


### PR DESCRIPTION
This PR updates the Django version to the latest `3.2` release (`3.2.5`). Locally I did not see any issues during the image build, when running the test suite, or doing a test run with the test API Directory instance. The PR aims to resolve #65.

Resource(s):
- https://docs.djangoproject.com/en/3.2/releases/3.2/