### PR TITLE
Changing the version to 3.10-slim-bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # FROM directive instructing base image to build upon
-FROM python:3.10-slim
+FROM python:3.10-slim-bullseye
 
 # Installs needed Linux packages
 RUN apt-get update && \


### PR DESCRIPTION
Fixes the current build failure 
```> ERROR [2/7] RUN apt-get update &&     apt-get install -y --no-install-recommends     build-essential default-libmysqlclient-dev git netcat &&     apt-get clean -y                                       3.5s
------
 > [2/7] RUN apt-get update &&     apt-get install -y --no-install-recommends     build-essential default-libmysqlclient-dev git netcat &&     apt-get clean -y:
#0 0.380 Get:1 http://deb.debian.org/debian bookworm InRelease [147 kB]
#0 0.545 Get:2 http://deb.debian.org/debian bookworm-updates InRelease [52.1 kB]
#0 0.614 Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
#0 0.687 Get:4 http://deb.debian.org/debian bookworm/main arm64 Packages [8802 kB]
#0 2.051 Get:5 http://deb.debian.org/debian-security bookworm-security/main arm64 Packages [44.2 kB]
#0 2.694 Fetched 9093 kB in 3s (3628 kB/s)
#0 2.694 Reading package lists...
#0 3.002 Reading package lists...
#0 3.288 Building dependency tree...
#0 3.361 Reading state information...
#0 3.364 Package netcat is a virtual package provided by:
#0 3.364   netcat-openbsd 1.219-1
#0 3.364   netcat-traditional 1.10-47
#0 3.364
#0 3.368 E: Package 'netcat' has no installation candidate```






