### PR TITLE
#91: Update dependencies - Django, Python, api-utils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # FROM directive instructing base image to build upon
-FROM python:3.10-slim-bullseye
+FROM python:3.14-slim-bookworm
 
 # Installs needed Linux packages
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    build-essential default-libmysqlclient-dev git netcat && \
+    build-essential default-libmysqlclient-dev git pkg-config netcat-openbsd && \
     apt-get clean -y
 
 COPY requirements.txt /requirements.txt

--- a/pe/main.py
+++ b/pe/main.py
@@ -1,10 +1,9 @@
 # standard libraries
 import logging
 from logging import Logger
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 # third-party libraries
-from django.utils.timezone import utc
 from umich_api.api_utils import ApiUtil
 
 # local libraries
@@ -26,7 +25,7 @@ def main(api_util: ApiUtil) -> None:
     :return: None
     :rtype: None
     """
-    start_time: datetime = datetime.now(tz=utc)
+    start_time: datetime = datetime.now(tz=timezone.utc)
     LOGGER.info(f'Starting new run at {start_time}')
 
     reports: list[Report] = list(Report.objects.all())
@@ -39,10 +38,10 @@ def main(api_util: ApiUtil) -> None:
         reporter: Reporter = Reporter(report)
         for exam in report.exams.all():
             LOGGER.info(f'Processing Exam: {exam.name}')
-            exam_start_time = datetime.now(tz=utc)
+            exam_start_time = datetime.now(tz=timezone.utc)
             exam_orca: ScoresOrchestration = ScoresOrchestration(api_util, exam)
             exam_orca.main()
-            exam_end_time = datetime.now(tz=utc)
+            exam_end_time = datetime.now(tz=timezone.utc)
             metadata: dict[str, datetime] = {
                 'start_time': exam_start_time,
                 'end_time': exam_end_time,
@@ -57,7 +56,7 @@ def main(api_util: ApiUtil) -> None:
         else:
             LOGGER.info(f'No email will be sent for the {report.name} report as there was no transmission activity.')
 
-    end_time: datetime = datetime.now(tz=utc)
+    end_time: datetime = datetime.now(tz=timezone.utc)
     delta: timedelta = end_time - start_time
 
     LOGGER.info(f'The run ended at {end_time}')

--- a/pe/migrations/0002_auto_20200622_1053.py
+++ b/pe/migrations/0002_auto_20200622_1053.py
@@ -2,7 +2,6 @@
 
 import datetime
 from django.db import migrations, models
-from django.utils.timezone import utc
 
 
 class Migration(migrations.Migration):
@@ -15,13 +14,13 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='exam',
             name='default_time_filter',
-            field=models.DateTimeField(default=datetime.datetime(2020, 1, 1, 0, 0, tzinfo=utc), verbose_name='Earliest Date & Time for Submission Search'),
+            field=models.DateTimeField(default=datetime.datetime(2020, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), verbose_name='Earliest Date & Time for Submission Search'),
             preserve_default=False,
         ),
         migrations.AddField(
             model_name='submission',
             name='graded_timestamp',
-            field=models.DateTimeField(default=datetime.datetime(2020, 1, 1, 0, 0, tzinfo=utc), verbose_name='Graded At Date & Time'),
+            field=models.DateTimeField(default=datetime.datetime(2020, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), verbose_name='Graded At Date & Time'),
             preserve_default=False,
         ),
         migrations.AlterField(

--- a/pe/orchestration.py
+++ b/pe/orchestration.py
@@ -1,11 +1,10 @@
 # standard libraries
 import json, logging, os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Union
 
 # third-party libraries
 from django.db.models import Count, QuerySet
-from django.utils.timezone import utc
 from requests import Response
 from umich_api.api_utils import ApiUtil
 
@@ -193,7 +192,7 @@ class ScoresOrchestration:
         if len(success_uniqnames) == 0:
             LOGGER.warning('No scores were transmitted successfully.')
         else:
-            timestamp: datetime = datetime.now(tz=utc)
+            timestamp: datetime = datetime.now(tz=timezone.utc)
 
             subs_to_update: list[Submission] = []
             for sub in subs_to_send:

--- a/pe/reporter.py
+++ b/pe/reporter.py
@@ -1,15 +1,16 @@
 # standard libraries
 import logging, os
-from datetime import datetime
+from datetime import datetime, timezone
 from smtplib import SMTPException
 from typing import Any
 
 # third-party libraries
+from django.conf import settings
 from django.core.mail import send_mail
 from django.db.models import QuerySet
 from django.forms.models import model_to_dict
 from django.template.loader import render_to_string
-from django.utils.timezone import localtime, utc
+from django.utils.timezone import localtime
 
 # local libraries
 from pe.models import Report
@@ -50,6 +51,7 @@ class Reporter:
             exam_dict: dict[str, Any] = model_to_dict(exam)
 
             exam_dict['time'] = self.exams_time_metadata[exam.id]
+            LOGGER.debug(f"Exam time metadata for {exam.id}: {exam_dict['time']}")
 
             success_sub_qs: QuerySet = exam.submissions.filter(
                 transmitted=True, transmitted_timestamp__gte=exam_dict['time']['start_time']
@@ -82,7 +84,12 @@ class Reporter:
         }
 
         support_email: str = os.getenv('SUPPORT_EMAIL', 'its.tl.staff@umich.edu')
-        self.context = {'report': report_dict, 'exams': exam_dicts, 'support_email': support_email}
+        self.context = {
+            'report': report_dict,
+            'exams': exam_dicts,
+            'support_email': support_email,
+            'datetime_format': settings.DATETIME_FORMAT
+        }
 
     def get_subject(self) -> str:
         """
@@ -91,7 +98,7 @@ class Reporter:
         :return: Email subject line referencing the report name, summary counts, and exams covered.
         :rtype: str
         """
-        local_time_str: str = localtime(datetime.now(utc)).strftime('%Y-%m-%d %I:%M %p')
+        local_time_str: str = localtime(datetime.now(timezone.utc)).strftime('%Y-%m-%d %I:%M %p')
 
         subject: str = ' - '.join([
             'Placement Exams Report',

--- a/pe/settings.py
+++ b/pe/settings.py
@@ -29,7 +29,6 @@ DATABASES: dict[str, dict[str, Any]] = {
 }
 
 DATETIME_FORMAT: str = "N j, Y g:i:s a"
-USE_L10N: bool = False
 
 if bool(int(os.getenv('EMAIL_DEBUG', '1'))):
     EMAIL_BACKEND: str = 'django.core.mail.backends.console.EmailBackend'

--- a/pe/templates/email.html
+++ b/pe/templates/email.html
@@ -18,15 +18,15 @@
         </tr>
         <tr>
             <td style="height: 30px; width: 250px">Process Start</td>
-            <td style="height: 30px; width: 250px">{{ exam.time.start_time }}</td>
+            <td style="height: 30px; width: 250px">{{ exam.time.start_time|date:datetime_format }}</td>
         </tr>
         <tr>
             <td style="height: 30px; width: 250px">Process End</td>
-            <td style="height: 30px; width: 250px">{{ exam.time.end_time }}</td>
+            <td style="height: 30px; width: 250px">{{ exam.time.end_time|date:datetime_format }}</td>
         </tr>
         <tr>
             <td style="height: 30px; width: 250px">Time used for filtering Canvas submissions</td>
-            <td style="height: 30px; width: 250px">{{ exam.time.sub_time_filter }}</td>
+            <td style="height: 30px; width: 250px">{{ exam.time.sub_time_filter|date:datetime_format }}</td>
         </tr>
         <tr>
             <td style="height: 30px; width: 250px">New submissions count</td>
@@ -47,7 +47,7 @@
             <td style="height: 30px; width: 100px">{{ submission.submission_id }}</td>
             <td style="height: 30px; width: 200px">{{ submission.student_uniqname }}</td>
             <td style="height: 30px; width: 100px">{{ submission.score }}</td>
-            <td style="height: 30px; width: 200px">{{ submission.graded_timestamp }}</td>
+            <td style="height: 30px; width: 200px">{{ submission.graded_timestamp|date:datetime_format }}</td>
         </tr>
 {% endfor %}
     </table>
@@ -68,7 +68,7 @@
             <td style="height: 30px; width: 100px">{{ submission.submission_id }}</td>
             <td style="height: 30px; width: 200px">{{ submission.student_uniqname }}</td>
             <td style="height: 30px; width: 100px">{{ submission.score }}</td>
-            <td style="height: 30px; width: 200px">{{ submission.graded_timestamp }}</td>
+            <td style="height: 30px; width: 200px">{{ submission.graded_timestamp|date:datetime_format }}</td>
         </tr>
 {% endfor %}
     </table>

--- a/pe/templates/email.txt
+++ b/pe/templates/email.txt
@@ -9,16 +9,16 @@ submissions from Canvas, and a count of new submissions. All times are in Easter
 Exam: {{ exam.name }}
 Canvas Course ID: {{ exam.course_id}}
 Canvas Assignment ID: {{ exam.assignment_id }}
-Process Start: {{ exam.time.start_time }}
-Process End: {{ exam.time.end_time }}
-Time used for filtering Canvas submissions: {{ exam.time.sub_time_filter }}
+Process Start: {{ exam.time.start_time|date:datetime_format }}
+Process End: {{ exam.time.end_time|date:datetime_format }}
+Time used for filtering Canvas submissions: {{ exam.time.sub_time_filter|date:datetime_format }}
 New submissions count: {{ exam.summary.new_count}}
 
 Successes: Scores transmitted
 {% if exam.successes %}
 Canvas ID - Student Uniqname - Score - Graded At
 {% for submission in exam.successes %}
-{{ submission.submission_id }} - {{ submission.student_uniqname }} - {{ submission.score }} - {{ submission.graded_timestamp }}
+{{ submission.submission_id }} - {{ submission.student_uniqname }} - {{ submission.score }} - {{ submission.graded_timestamp|date:datetime_format }}
 {% endfor %}
 {% else %}
 The application did not send any scores for the {{ exam.name }} exam.
@@ -28,7 +28,7 @@ Failures: Scores not transmitted
 {% if exam.failures %}
 Canvas ID - Student Uniqname - Score - Graded At
 {% for submission in exam.failures %}
-{{ submission.submission_id }} - {{ submission.student_uniqname }} - {{ submission.score }} - {{ submission.graded_timestamp }}
+{{ submission.submission_id }} - {{ submission.student_uniqname }} - {{ submission.score }} - {{ submission.graded_timestamp|date:datetime_format }}
 {% endfor %}
 {% else %}
 The application did not fail to send any scores for the {{ exam.name }} exam.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coverage==6.5.0
-Django==4.2.30
-mysqlclient==2.1.1
-python-dotenv==0.21.0
-requests==2.28.1
--e git+https://github.com/tl-its-umich-edu/api-utils-python@v3.0#egg=umich-api
+Django==5.2.14
+mysqlclient==2.2.8
+python-dotenv==1.2.2
+requests==2.33.0
+-e git+https://github.com/tl-its-umich-edu/api-utils-python@v4.0#egg=umich-api

--- a/test/test_api_retry.py
+++ b/test/test_api_retry.py
@@ -1,12 +1,11 @@
 # standard libraries
 import json, logging, os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Union
 from unittest.mock import MagicMock, patch
 
 # third-party libraries
 from django.test import TestCase
-from django.utils.timezone import utc
 from requests import Response
 from umich_api.api_utils import ApiUtil
 
@@ -37,7 +36,7 @@ class TestApiRetry(TestCase):
         # "Potions Validation" from test_04.json
         some_course_id: int = 888888
         some_assignment_id: int = 111112
-        some_filter: datetime = datetime(2020, 6, 1, 0, 0, 0, tzinfo=utc)
+        some_filter: datetime = datetime(2020, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
 
         self.get_scores_url: str = (
             f'{CANVAS_URL_BEGIN}/courses/{some_course_id}/students/submissions'

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -89,5 +89,5 @@ class MainTestCase(TestCase):
 
         dada_report: Report = Report.objects.get(id=3)
         failed_submissions_qs: QuerySet = dada_report.exams.first().submissions.filter(transmitted=False)
-        self.assertTrue(len(failed_submissions_qs), 2)
+        self.assertEqual(len(failed_submissions_qs), 1)
         self.assertEqual(len(mail.outbox), 1)

--- a/test/test_orch.py
+++ b/test/test_orch.py
@@ -1,6 +1,6 @@
 # standard libraries
 import json, logging, os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import MagicMock, patch
 from urllib.parse import quote_plus
@@ -8,7 +8,6 @@ from urllib.parse import quote_plus
 # third-party libraries
 from django.db.models import QuerySet
 from django.test import TestCase
-from django.utils.timezone import utc
 from requests import Response
 from umich_api.api_utils import ApiUtil
 
@@ -63,7 +62,7 @@ class ScoresOrchestrationTestCase(TestCase):
         some_orca: ScoresOrchestration = ScoresOrchestration(self.api_handler, potions_place_exam)
 
         # Extra second for standard one-second increment
-        self.assertEqual(some_orca.sub_time_filter, datetime(2020, 6, 12, 16, 0, 1, tzinfo=utc))
+        self.assertEqual(some_orca.sub_time_filter, datetime(2020, 6, 12, 16, 0, 1, tzinfo=timezone.utc))
 
     def test_constructor_uses_default_filter_when_no_subs(self):
         """
@@ -72,7 +71,7 @@ class ScoresOrchestrationTestCase(TestCase):
         dada_place_exam: Exam = Exam.objects.get(id=3)
 
         some_orca: ScoresOrchestration = ScoresOrchestration(self.api_handler, dada_place_exam)
-        self.assertEqual(some_orca.sub_time_filter, datetime(2020, 7, 1, 0, 0, 0, tzinfo=utc))
+        self.assertEqual(some_orca.sub_time_filter, datetime(2020, 7, 1, 0, 0, 0, tzinfo=timezone.utc))
 
     def test_get_sub_dicts_for_exam_with_null_response(self):
         """
@@ -176,8 +175,8 @@ class ScoresOrchestrationTestCase(TestCase):
                 'attempt_num': 1,
                 'student_uniqname': 'cchang',
                 'score': 200.0,
-                'submitted_timestamp': datetime(2020, 6, 20, 10, 35, 1, tzinfo=utc),
-                'graded_timestamp': datetime(2020, 6, 20, 10, 45, 0, tzinfo=utc)
+                'submitted_timestamp': datetime(2020, 6, 20, 10, 35, 1, tzinfo=timezone.utc),
+                'graded_timestamp': datetime(2020, 6, 20, 10, 45, 0, tzinfo=timezone.utc)
             }
         )
         self.assertEqual(
@@ -187,8 +186,8 @@ class ScoresOrchestrationTestCase(TestCase):
                 'attempt_num': 1,
                 'student_uniqname': 'hpotter',
                 'score': 125.0,
-                'submitted_timestamp': datetime(2020, 6, 19, 17, 30, 5, tzinfo=utc),
-                'graded_timestamp': datetime(2020, 6, 19, 17, 45, 33, tzinfo=utc)
+                'submitted_timestamp': datetime(2020, 6, 19, 17, 30, 5, tzinfo=timezone.utc),
+                'graded_timestamp': datetime(2020, 6, 19, 17, 45, 33, tzinfo=timezone.utc)
             }
         )
 
@@ -214,7 +213,7 @@ class ScoresOrchestrationTestCase(TestCase):
                 'student_uniqname': 'nlongbottom',
                 'score': 500.0,
                 'submitted_timestamp': None,
-                'graded_timestamp': datetime(2020, 7, 7, 13, 22, 49, tzinfo=utc)
+                'graded_timestamp': datetime(2020, 7, 7, 13, 22, 49, tzinfo=timezone.utc)
             }
         )
 
@@ -233,7 +232,7 @@ class ScoresOrchestrationTestCase(TestCase):
         send_scores properly transmits data to M-Pathways API and updates all submission records.
         """
         resp_data: dict[str, Any] = self.mpathways_resp_data[0]
-        current_dt: datetime = datetime.now(tz=utc)
+        current_dt: datetime = datetime.now(tz=timezone.utc)
         potions_val_exam: Exam = Exam.objects.get(id=2)
         some_orca: ScoresOrchestration = ScoresOrchestration(self.api_handler, potions_val_exam)
         val_subs: list[Submission] = list(some_orca.exam.submissions.filter(transmitted=False))
@@ -270,7 +269,7 @@ class ScoresOrchestrationTestCase(TestCase):
         send_scores updates exam-specific records with transmitted as True and timestamp only when successful.
         """
         resp_data: dict[str, Any] = self.mpathways_resp_data[1]
-        current_dt: datetime = datetime.now(tz=utc)
+        current_dt: datetime = datetime.now(tz=timezone.utc)
         potions_val_exam: Exam = Exam.objects.get(id=2)
         some_orca: ScoresOrchestration = ScoresOrchestration(self.api_handler, potions_val_exam)
         val_subs: list[Submission] = some_orca.exam.submissions.filter(transmitted=False).all()
@@ -366,7 +365,7 @@ class ScoresOrchestrationTestCase(TestCase):
         """
         The main process pulls, stores, and sends scores with duplicate uniqnames on different runs.
         """
-        current_dt: datetime = datetime.now(tz=utc)
+        current_dt: datetime = datetime.now(tz=timezone.utc)
         potions_place_exam: Exam = Exam.objects.get(id=1)
         some_orca: ScoresOrchestration = ScoresOrchestration(self.api_handler, potions_place_exam)
 
@@ -399,7 +398,7 @@ class ScoresOrchestrationTestCase(TestCase):
         """
         The main process pulls, stores, and sends scores with duplicate uniqnames on the same run.
         """
-        current_dt: datetime = datetime.now(tz=utc)
+        current_dt: datetime = datetime.now(tz=timezone.utc)
         potions_place_exam: Exam = Exam.objects.get(id=1)
         some_orca: ScoresOrchestration = ScoresOrchestration(self.api_handler, potions_place_exam)
 

--- a/test/test_pe.py
+++ b/test/test_pe.py
@@ -1,12 +1,11 @@
 # standard libraries
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Union
 
 # third-party libraries
 from django.core.management import call_command
 from django.test import TestCase
-from django.utils.timezone import utc
 
 # Local libraries
 from pe.models import Report, Exam, Submission
@@ -62,7 +61,7 @@ class LoadFixturesTestCase(TestCase):
                 "sa_code": "PP",
                 "course_id": 888888,
                 "assignment_id": 111111,
-                "default_time_filter": datetime(2020, 6, 1, 0, 0, 0, tzinfo=utc)
+                "default_time_filter": datetime(2020, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
             }
         )
 
@@ -79,7 +78,7 @@ class LoadFixturesTestCase(TestCase):
                 "sa_code": "PV",
                 "course_id": 888888,
                 "assignment_id": 111112,
-                "default_time_filter": datetime(2020, 5, 1, 0, 0, 0, tzinfo=utc)
+                "default_time_filter": datetime(2020, 5, 1, 0, 0, 0, tzinfo=timezone.utc)
             }
         )
 
@@ -104,7 +103,7 @@ class LoadFixturesTestCase(TestCase):
         placement_exam = Exam.objects.get(sa_code='PP')
         self.assertEqual(placement_exam.name, 'Potions Placement Advanced')
         self.assertEqual(placement_exam.course_id, 888889)
-        self.assertEqual(placement_exam.default_time_filter, datetime(2020, 6, 2, 12, 0, 0, tzinfo=utc))
+        self.assertEqual(placement_exam.default_time_filter, datetime(2020, 6, 2, 12, 0, 0, tzinfo=timezone.utc))
 
         # Test Potions Validation report and assignment_id changed
         validation_exam = Exam.objects.get(name='Potions Validation')
@@ -166,7 +165,7 @@ class LoadFixturesTestCase(TestCase):
                 "report_id": 3,
                 "course_id": 999999,
                 "assignment_id": 222222,
-                "default_time_filter": datetime(2020, 7, 1, 0, 0, 0, tzinfo=utc)
+                "default_time_filter": datetime(2020, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
             }
         )
 
@@ -199,10 +198,10 @@ class LoadFixturesTestCase(TestCase):
                 'attempt_num': 1,
                 "exam_id": 1,
                 "student_uniqname": "hpotter",
-                "submitted_timestamp": datetime(2020, 6, 12, 8, 15, 30, tzinfo=utc),
+                "submitted_timestamp": datetime(2020, 6, 12, 8, 15, 30, tzinfo=timezone.utc),
                 "score": 100.0,
                 "transmitted": True,
-                "transmitted_timestamp": datetime(2020, 6, 12, 12, 0, 30, tzinfo=utc)
+                "transmitted_timestamp": datetime(2020, 6, 12, 12, 0, 30, tzinfo=timezone.utc)
             }
         )
 
@@ -278,7 +277,7 @@ class CustomMethodsTestCase(TestCase):
         """
         potions_exam = Exam.objects.get(id=1)
         last_sub_graded_dt: Union[datetime, None] = potions_exam.get_last_sub_graded_datetime()
-        self.assertTrue(last_sub_graded_dt, datetime(2020, 6, 12, 12, 0, 30, tzinfo=utc))
+        self.assertTrue(last_sub_graded_dt, datetime(2020, 6, 12, 12, 0, 30, tzinfo=timezone.utc))
 
     def test_get_last_sub_graded_datetime_without_submissions(self):
         """

--- a/test/test_pe.py
+++ b/test/test_pe.py
@@ -44,7 +44,7 @@ class LoadFixturesTestCase(TestCase):
         # Test exams loaded
         exams_queryset = Exam.objects.all()
         self.assertTrue(exams_queryset.exists())
-        self.assertTrue(len(exams_queryset), 2)
+        self.assertEqual(len(exams_queryset), 2)
         if not exams_queryset.exists() and len(exams_queryset) != 2:
             return None
 
@@ -107,7 +107,7 @@ class LoadFixturesTestCase(TestCase):
 
         # Test Potions Validation report and assignment_id changed
         validation_exam = Exam.objects.get(name='Potions Validation')
-        self.assertTrue(validation_exam.assignment_id, 111113)
+        self.assertEqual(validation_exam.assignment_id, 111113)
 
         new_report_queryset = Report.objects.filter(id=2)
         self.assertTrue(new_report_queryset.exists())
@@ -129,7 +129,7 @@ class LoadFixturesTestCase(TestCase):
 
         # Test previous Potions report remains and new DADA report was added
         report_queryset = Report.objects.all()
-        self.assertTrue(len(report_queryset), 2)
+        self.assertEqual(len(report_queryset), 3)
         self.assertTrue(report_queryset.filter(id=1).exists())
 
         dada_queryset = report_queryset.filter(id=3)
@@ -148,9 +148,9 @@ class LoadFixturesTestCase(TestCase):
 
         # Test previous exams remain and new DADA Placement exam added
         exams_queryset = Exam.objects.all()
-        self.assertTrue(len(exams_queryset), 3)
-        previous_queryset = exams_queryset.filter(name__in=['Potions Placement Advancecd', 'Potions Validation'])
-        self.assertTrue(len(previous_queryset), 2)
+        self.assertEqual(len(exams_queryset), 3)
+        previous_queryset = exams_queryset.filter(name__in=['Potions Placement Advanced', 'Potions Validation'])
+        self.assertEqual(len(previous_queryset), 2)
 
         data_exam_queryset = exams_queryset.filter(name='DADA Placement')
         self.assertTrue(data_exam_queryset.exists())
@@ -277,7 +277,7 @@ class CustomMethodsTestCase(TestCase):
         """
         potions_exam = Exam.objects.get(id=1)
         last_sub_graded_dt: Union[datetime, None] = potions_exam.get_last_sub_graded_datetime()
-        self.assertTrue(last_sub_graded_dt, datetime(2020, 6, 12, 12, 0, 30, tzinfo=timezone.utc))
+        self.assertEqual(last_sub_graded_dt, datetime(2020, 6, 12, 16, 0, 0, tzinfo=timezone.utc))
 
     def test_get_last_sub_graded_datetime_without_submissions(self):
         """

--- a/test/test_reporter.py
+++ b/test/test_reporter.py
@@ -1,6 +1,6 @@
 # standard libraries
 import json, logging, os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 from django.core import mail
 from django.core.mail import EmailMultiAlternatives
 from django.test import TestCase
-from django.utils.timezone import utc
 from requests import Response
 from umich_api.api_utils import ApiUtil
 
@@ -61,7 +60,7 @@ class ReporterTestCase(TestCase):
                     MagicMock(spec=Response, status_code=200, text=json.dumps(mpathways_resp_data[2]))
                 ]
 
-                fake_running_dt: datetime = datetime(2020, 6, 25, 16, 0, 0, tzinfo=utc)
+                fake_running_dt: datetime = datetime(2020, 6, 25, 16, 0, 0, tzinfo=timezone.utc)
                 self.exams_time_metadata: dict[int, dict[str, datetime]] = dict()
                 for exam in self.potions_report.exams.all():
                     start: datetime = fake_running_dt
@@ -98,7 +97,7 @@ class ReporterTestCase(TestCase):
         reporter.prepare_context()
 
         self.assertEqual((reporter.total_successes, reporter.total_failures, reporter.total_new), (4, 1, 2))
-        self.assertEqual(sorted(list(reporter.context.keys())), ['exams', 'report', 'support_email'])
+        self.assertEqual(sorted(list(reporter.context.keys())), ['datetime_format','exams', 'report', 'support_email'])
         self.assertEqual(reporter.context['report'], {
             'id': 1,
             'name': 'Potions',
@@ -137,7 +136,7 @@ class ReporterTestCase(TestCase):
                 'submission_id': 123458,
                 'student_uniqname': 'rweasley',
                 'score': 150.0,
-                'graded_timestamp': datetime(2020, 6, 12, 16, 0, 0, tzinfo=utc)
+                'graded_timestamp': datetime(2020, 6, 12, 16, 0, 0, tzinfo=timezone.utc)
             }
         )
         val_success_ids: list[int] = sorted(


### PR DESCRIPTION
- Major Upgrades: Django 4.2 -> 5.2, Python 3.10 bullseye slim -> 3.14 bookworm slim (debian 11 -> 12)
- Minor Upgrades ([API utils 4.0 update](https://github.com/tl-its-umich-edu/api-utils-python/pull/46)): python-dotenv to 1.2.2, requests to 2.33.0

Timezone formatting had to change for the Django migration, so I brought in our [DATETIME_FORMAT](https://github.com/tl-its-umich-edu/placement-exams/blob/9188c29b397d5d5277ab4a55a1a63dd9b01af263/pe/settings.py#L31) setting into the email templates. Test suite is tweaked to account for this,  and there should be no change to how the emails look in production.

Test plan
- Test suite fully passes (made some fixes to problems copilot noticed)
- happy path test - locally run the job using api directory test/dev credentials without previous data (email sends). Then try again with previous data (no email sends)
- optional integration test (to be safe) - add a new score in canvas that is newer than the latest graded_timestamp for prior scores of the respective test (defined in `fixtures.json`). check if the score is properly picked up and a new email is drafted just for that score.
