### PR TITLE
#93 MySQL 8.4 upgrade, use SSL cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ this README. However, some details about how the job is configured are provided 
 The files described in the **Configuration** section above need to be made available to running placement-exams
 containers as [OpenShift Secrets](https://docs.openshift.com/container-platform/3.7/dev_guide/secrets.html).
 A volume containing versions of `.env` and `fixtures.json` should be mapped to a configuration directory,
-typically `config/secrets`. These details will be specified in a YAML configuration file defining the pod. 
+typically `config/secrets`. Additionally, this volume could contain a certificate authority file `db-ca.pem` that will connect to your test/production database, which will only be enforced upon start if the file exists. These details will be specified in a YAML configuration file defining the pod. 
 
 In OpenShift, some application settings are controlled by specifying environment variables in the pod
 configuration file. More details on these environment variables -- and whether they are optional or required --

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -21,6 +21,8 @@ DB_PORT=3306
 SECRET_KEY=
 # Default is America/Detroit
 TIME_ZONE=
+# For DB connection, enforced when a CA file is in secrets directory
+SSL_MODE=
 
 # Email
 # Determines whether to simulate email sending or not (actually send it)

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -23,6 +23,8 @@ SECRET_KEY=
 TIME_ZONE=
 # For DB connection, enforced when a CA file is in secrets directory
 SSL_MODE=
+# Overwrite the CA file location, including the filename
+SSL_CA_FILEPATH=
 
 # Email
 # Determines whether to simulate email sending or not (actually send it)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   mysql:
-    image: mysql:8.0
+    image: mysql:8.4-oracle
     restart: on-failure
     command: ['--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
     environment:
@@ -12,7 +12,6 @@ services:
       - MYSQL_DATABASE=placement_exams_local
       - MYSQL_USER=pe_user
       - MYSQL_PASSWORD=pe_pw
-    entrypoint: ['docker-entrypoint.sh', '--default-authentication-plugin=mysql_native_password']
     ports:
       - "5555:3306"
     volumes:

--- a/pe/settings.py
+++ b/pe/settings.py
@@ -23,7 +23,7 @@ DATABASES: dict[str, dict[str, Any]] = {
         'OPTIONS': {
             'charset': 'utf8mb4',
             **({
-                'ssl_mode': 'VERIFY_CA',
+                'ssl_mode': os.getenv('SSL_MODE', 'REQUIRED'),
                 'ssl': {'ca': os.path.join(CONFIG_DIR, 'db-ca.pem')}
             } if os.path.isfile(os.path.join(CONFIG_DIR, 'db-ca.pem')) else {}),
         },

--- a/pe/settings.py
+++ b/pe/settings.py
@@ -20,7 +20,13 @@ DATABASES: dict[str, dict[str, Any]] = {
         'PASSWORD': os.getenv('DB_PASSWORD', 'pe_pw'),
         'HOST': os.getenv('DB_HOST', 'placement_exams_mysql'),
         'PORT': os.getenv('DB_PORT', '3306'),
-        'OPTIONS': {'charset': 'utf8mb4'},
+        'OPTIONS': {
+            'charset': 'utf8mb4',
+            **({
+                'ssl_mode': 'VERIFY_CA',
+                'ssl': {'ca': os.path.join(CONFIG_DIR, 'db-ca.pem')}
+            } if os.path.isfile(os.path.join(CONFIG_DIR, 'db-ca.pem')) else {}),
+        },
         'TEST': {
             'CHARSET': 'utf8mb4',
             'COLLATION': 'utf8mb4_unicode_ci'

--- a/pe/settings.py
+++ b/pe/settings.py
@@ -11,6 +11,7 @@ from constants import ROOT_DIR
 BASE_DIR: str = ROOT_DIR
 
 CONFIG_DIR: str = os.path.join(BASE_DIR, os.getenv('ENV_DIR', os.path.join('config', 'secrets')))
+DEFAULT_SSL_CA_FILEPATH: str = os.path.join(CONFIG_DIR, 'db-ca.pem')
 
 DATABASES: dict[str, dict[str, Any]] = {
     'default': {
@@ -24,8 +25,8 @@ DATABASES: dict[str, dict[str, Any]] = {
             'charset': 'utf8mb4',
             **({
                 'ssl_mode': os.getenv('SSL_MODE', 'REQUIRED'),
-                'ssl': {'ca': os.path.join(CONFIG_DIR, 'db-ca.pem')}
-            } if os.path.isfile(os.path.join(CONFIG_DIR, 'db-ca.pem')) else {}),
+                'ssl': {'ca': os.getenv('SSL_CA_FILEPATH', DEFAULT_SSL_CA_FILEPATH)}
+            } if os.path.isfile(os.getenv('SSL_CA_FILEPATH', DEFAULT_SSL_CA_FILEPATH)) else {}),
         },
         'TEST': {
             'CHARSET': 'utf8mb4',


### PR DESCRIPTION
Local test: 
- delete old `.data` folder and start application. Migrations, fixtures loading, and job should be successful.
- Test suite is successful
- To attempt connection to Test MySQL DB using SSL, edit the `DB_*` configurations in `.env` with the test db credentials. Add a pem file and name it`db-ca.pem` to your local secrets directory, which should enforce the connection. The `fixtures.json` file may cause problems so I removed it temporarily. You may need to delete and rebuild the Docker volume, as well as remove your `fixtures.json` file, which could be out of sync with the Test DB.  

~~NOTE: In my local testing, the pem file is currently not completing the connection locally (I'm seeing `TLS/SSL error: Validation of SSL server certificate failed`), unless you use the REAL `*.amazonaws.com` hostname instead of the `*.it.umich.edu` Test DB vanity CNAME.  (see slack discussion for full hostname URL)~~
Should now work with MODE = "REQUIRED"